### PR TITLE
[next] Merge upstream master ref, for currency

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -16,5 +16,5 @@ addpylib ${LAYERDIR}/lib oeqa
 
 LAYERDEPENDS_meta-mingw = "core"
 
-LAYERSERIES_COMPAT_meta-mingw = "nanbield"
+LAYERSERIES_COMPAT_meta-mingw = "scarthgap"
 

--- a/recipes-support/libiconv/libiconv_1.15.bb
+++ b/recipes-support/libiconv/libiconv_1.15.bb
@@ -6,7 +6,7 @@ SECTION = "libs"
 NOTES = "Needs to be stripped down to: ascii iso8859-1 eucjp iso-2022jp gb utf8"
 PROVIDES = "virtual/libiconv"
 PR = "r1"
-LICENSE = "LGPLv3"
+LICENSE = "LGPL-3.0-only"
 LIC_FILES_CHKSUM = "file://COPYING.LIB;md5=9f604d8a4f8e74f4f5140845a21b6674 \
                     file://libcharset/COPYING.LIB;md5=9f604d8a4f8e74f4f5140845a21b6674"
 


### PR DESCRIPTION
This patchset merges this repo's upstream master ref into our nilrt/master/next mainline.

AB#2565252

# Testing
* [x] Built the core package feed.
* [x] Built the recovery media ISO and provisioned a VM.
* [x] Booted the VM through getty.