### PR TITLE
meta-mingw: Currency merge with upstream scarthgap branch

### DIFF
--- a/recipes-core/gettext/gettext_%.bbappend
+++ b/recipes-core/gettext/gettext_%.bbappend
@@ -7,6 +7,7 @@ SRC_URI:append:mingw32 = " \
 FILES:libgettextlib:mingw32 = "${bindir}/libgettextlib-*.dll"
 FILES:libgettextsrc:mingw32 = "${bindir}/libgettextsrc-*.dll"
 
-PACKAGES:prepend:mingw32 = "libintl "
+PACKAGES:prepend:mingw32 = "libintl ${LOCALEBASEPN}-locale-alias "
 FILES:libintl:mingw32 = "${bindir}/libintl*.dll"
+FILES:${LOCALEBASEPN}-locale-alias = "${datadir}/locale/locale.alias"
 


### PR DESCRIPTION
This is the periodic currency merge with upstream `scarthgap` branch.

Did the merge using `upstream_merge.sh` script. No conflicts.

WI: [AB#2468923](https://dev.azure.com/ni/DevCentral/_workitems/edit/2468923)

### Testing
- [x] bitbake packagefeed-ni-core
- [x] bitbake packagegroup-ni-desirable
- [x] bitbake package-index && bitbake nilrt-base-system-image
- [x] Installed BSI on a VM and verified it boots

### Note to maintainers
Please complete this merge manually to avoid upstream hashes being changed by GH.